### PR TITLE
Fix virtual scroller for multiple columns with unequal children sizes

### DIFF
--- a/projects/ngx-virtual-scroller/src/lib/ngx-virtual-scroller.component.ts
+++ b/projects/ngx-virtual-scroller/src/lib/ngx-virtual-scroller.component.ts
@@ -1276,8 +1276,8 @@ export class VirtualScrollerComponent implements OnInit, OnChanges, OnDestroy {
                 }
             }
             
-            arrayStartIndex = i;
-            arrayEndIndex = j
+            arrayStartIndex = i * dimensions.itemsPerWrapGroup;
+            arrayEndIndex = j * dimensions.itemsPerWrapGroup;
         } else {
             scrollPercentage = scrollPosition / dimensions.scrollLength;
 


### PR DESCRIPTION
I've noticed that [after the latest changes related to calculations for unequal children](https://github.com/iharbeck/ngx-virtual-scroller/pull/3), the virtual scroller stopped working for multiple columns with unequal children. This is because `i` and `j` are not the element indexes but rather the indexes of the groups. This causes only a part of the virtual scroll to render.


![chrome-capture-2024-7-27](https://github.com/user-attachments/assets/afb12582-5810-4ac6-b910-c0823077e16c)


To fix this, I multiplied `i` and `j` by `itemsPerWrapGroup`, and now everything seems to work.