### PR TITLE
Fixed header moving while scrolling and add sticky footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,30 +299,15 @@ export class ListWithApiComponent implements OnChanges {
 }
 ```
 
-## With HTML Table
+## Sticky header and footer
 
-*Note* - The `#header` angular selector will make the `<thead>` element fixed to top. If you want the header to scroll out of view don't add the `#header` angular element ref.
+*Note* - The `tab-header` angular selector will make the element fixed to top and the `tab-footer` angular selector will make the element fixed to bottom.
 
 ```html
 <virtual-scroller #scroll [items]="myItems">
-    <table>
-        <thead #header>
-            <th>Index</th>
-            <th>Name</th>
-            <th>Gender</th>
-            <th>Age</th>
-            <th>Address</th>
-        </thead>
-        <tbody #container>
-            <tr *ngFor="let item of scroll.viewPortItems">
-                <td>{{item.index}}</td>
-                <td>{{item.name}}</td>
-                <td>{{item.gender}}</td>
-                <td>{{item.age}}</td>
-                <td>{{item.address}}</td>
-            </tr>
-        </tbody>
-    </table>
+    <my-custom-header-component tab-header> </my-custom-header-component>
+    <my-custom-component *ngFor="let item of scroll.viewPortItems"> </my-custom-component>
+    <my-custom-footer-component tab-footer> </my-custom-footer-component>
 </virtual-scroller>
 ```
 

--- a/projects/ngx-virtual-scroller/src/lib/ngx-virtual-scroller.component.ts
+++ b/projects/ngx-virtual-scroller/src/lib/ngx-virtual-scroller.component.ts
@@ -95,10 +95,12 @@ export interface IViewport extends IPageInfo {
     selector: 'virtual-scroller,[virtualScroller]',
     exportAs: 'virtualScroller',
     template: `
+        <ng-content select="[tab-header]"></ng-content>
         <div class="total-padding" #invisiblePadding></div>
         <div class="scrollable-content" #content>
             <ng-content></ng-content>
         </div>
+        <ng-content select="[tab-footer]"></ng-content>
     `,
     host: {
         '[class.horizontal]': 'horizontal',
@@ -398,9 +400,6 @@ export class VirtualScrollerComponent implements OnInit, OnChanges, OnDestroy {
 
     @ViewChild('invisiblePadding', {read: ElementRef, static: true})
     protected invisiblePaddingElementRef: ElementRef;
-
-    @ContentChild('header', {read: ElementRef, static: false})
-    protected headerElementRef: ElementRef;
 
     @ContentChild('container', {read: ElementRef, static: false})
     protected containerElementRef: ElementRef;
@@ -815,14 +814,6 @@ export class VirtualScrollerComponent implements OnInit, OnChanges, OnDestroy {
                     }
                 }
 
-                if (this.headerElementRef) {
-                    let scrollPosition = this.getScrollElement()[this._scrollType];
-                    let containerOffset = this.getElementsOffset();
-                    let offset = Math.max(scrollPosition - viewport.padding - containerOffset + this.headerElementRef.nativeElement.clientHeight, 0);
-                    this.renderer.setStyle(this.headerElementRef.nativeElement, 'transform', `${this._translateDir}(${offset}px)`);
-                    this.renderer.setStyle(this.headerElementRef.nativeElement, 'webkitTransform', `${this._translateDir}(${offset}px)`);
-                }
-
                 const changeEventArg: IPageInfo = (startChanged || endChanged) ? {
                     startIndex: viewport.startIndex,
                     endIndex: viewport.endIndex,
@@ -1186,10 +1177,6 @@ export class VirtualScrollerComponent implements OnInit, OnChanges, OnDestroy {
             scrollLength += Math.round(numUnknownChildSizes * defaultScrollLengthPerWrapGroup);
         } else {
             scrollLength = numberOfWrapGroups * defaultScrollLengthPerWrapGroup;
-        }
-
-        if (this.headerElementRef) {
-            scrollLength += this.headerElementRef.nativeElement.clientHeight;
         }
 
         let viewportLength = this.horizontal ? viewportWidth : viewportHeight;


### PR DESCRIPTION
This modification fixes the issue of the header moving while scrolling (https://github.com/rintoj/ngx-virtual-scroller/issues/406)
And add a sticky footer